### PR TITLE
fix: removed StrictMode to avoid double rendering of footer

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -14,7 +14,6 @@ if (!rootElement) {
 }
 
 createRoot(rootElement).render(
-  <StrictMode>
+
     <App />
-  </StrictMode>
 );


### PR DESCRIPTION
Removed React StrictMode to prevent double rendering of the footer component, which fixes UI glitches during rendering.


<img width="1920" alt="Screenshot 2025-05-27 at 1 01 58 AM" src="https://github.com/user-attachments/assets/00daf287-f9df-4d7b-a8d3-17a0880637d1" />
<img width="1920" alt="Screenshot 2025-05-27 at 1 02 07 AM" src="https://github.com/user-attachments/assets/983be91a-dae7-4c0f-829c-23deac6f8b93" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the app rendering process by removing the strict mode wrapper around the main application component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->